### PR TITLE
Ignored error leads to ignoring all errors.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+version: '{build}'
+platform:
+  - x64
+clone_depth: 1
+max_jobs: 3
+cache:
+  - '%LOCALAPPDATA%\Composer'
+  - '%LOCALAPPDATA%\Temp\Chocolatey'
+environment:
+  ANSICON: 121x90 (121x90)
+  matrix:
+    # @todo learn how to have Chocolately install latest minor without specifying patch version.
+    - { PHP_VERSION: '7.2.33' }
+    - { PHP_VERSION: '7.3.22' }
+install:
+  # Enable Windows Update service, needed to install vcredist2015 (dependency of php)
+  - ps: Set-Service wuauserv -StartupType Manual
+  - choco config set cacheLocation %LOCALAPPDATA%\Temp\Chocolatey
+  - choco install -y php --version %PHP_VERSION%
+  - choco install -y composer
+  - refreshenv
+  - SET | more
+  - composer install --no-interaction --no-progress --no-suggest --prefer-dist
+  - set COMPOSER_MEMORY_LIMIT=-1&& composer create-project drupal-composer/drupal-project:8.x-dev %APPVEYOR_BUILD_FOLDER%\..\drupal --no-interaction --prefer-dist --ignore-platform-reqs
+build: off
+test_script:
+  - php drupal-check --version
+  - php drupal-check %APPVEYOR_BUILD_FOLDER%\..\drupal\web\core\install.php -vvv

--- a/src/Command/CheckCommand.php
+++ b/src/Command/CheckCommand.php
@@ -153,7 +153,7 @@ class CheckCommand extends Command
             $configuration_data['parameters']['level'] = 4;
 
             $ignored_analysis_errors = [
-                '#Unsafe usage of new static()#'
+                '#Unsafe usage of new static\(\)#'
             ];
             $configuration_data['parameters']['ignoreErrors'] = array_merge($ignored_analysis_errors, $configuration_data['parameters']['ignoreErrors']);
         } else {

--- a/src/Command/CheckCommand.php
+++ b/src/Command/CheckCommand.php
@@ -211,10 +211,6 @@ class CheckCommand extends Command
             return 1;
         }
 
-        if (substr(PHP_OS, 0, 3) == 'WIN') {
-            $phpstanBin = "php $phpstanBin";
-        }
-
         $output->writeln(sprintf('<comment>PHPStan path: %s</comment>', $phpstanBin), OutputInterface::VERBOSITY_DEBUG);
         $configuration_encoded = Neon::encode($configuration_data, Neon::BLOCK);
         $configuration = sys_get_temp_dir() . '/drupal_check_phpstan_' . time() . '.neon';
@@ -232,6 +228,10 @@ class CheckCommand extends Command
             $configuration,
             '--error-format=' . $input->getOption('format')
         ];
+
+        if (substr(PHP_OS, 0, 3) == 'WIN') {
+            array_unshift($command, 'php');
+        }
 
         if ($input->getOption('no-progress')) {
             $command[] = '--no-progress';


### PR DESCRIPTION
Ignored error #Unsafe usage of new static()# has an unescaped '()' which leads to ignoring all errors. Use '\(\)' instead.